### PR TITLE
Package data needs to be a dict of keys to array of wildcards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+dist
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     entry_points= {
         'console_scripts': [
-        'bfx-qc-reporter = bfx_qc_reporter.__main__:main'
+            'bfx-qc-reporter = bfx_qc_reporter.__main__:main'
         ]
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-#from setuptools import setup, find_packages
 
 setup(
     name = "bfx-qc-reporter",
@@ -9,11 +8,9 @@ setup(
     description = "Simple scripts to collate per-sample bioinformatic QC metrics. Supports fgbio, Picard, and CSV metric files.",
     url = "https://github.com/nh13/bfx-qc-reporter",
     license = "MIT",
-	#packages = find_packages("src/python"),
-	packages = ["bfx_qc_reporter", "bfx_qc_reporter.util"],
-	package_dir = {"bfx_qc_reporter" : "src/python/bfx_qc_reporter", "bfx_qc_reporter.util" : "src/python/bfx_qc_reporter/util"},
-	#package_data = {"bfx_qc_reporter" : "resources/*.csv"},
-        package_data = {"bfx_qc_reporter" : ["src/python/bfx_qc_reporter/resources/*.csv"]},
+    packages = ["bfx_qc_reporter", "bfx_qc_reporter.util"],
+    package_dir = {"bfx_qc_reporter" : "src/python/bfx_qc_reporter", "bfx_qc_reporter.util" : "src/python/bfx_qc_reporter/util"},
+    package_data = {"bfx_qc_reporter" : ["src/python/bfx_qc_reporter/resources/*.csv"]},
     install_requires = [],
     classifiers = [
         "Development Status :: 3 - Alpha",
@@ -24,7 +21,7 @@ setup(
     ],
     entry_points= {
         'console_scripts': [
-			'bfx-qc-reporter = bfx_qc_reporter.__main__:main'
+        'bfx-qc-reporter = bfx_qc_reporter.__main__:main'
         ]
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
 	packages = ["bfx_qc_reporter", "bfx_qc_reporter.util"],
 	package_dir = {"bfx_qc_reporter" : "src/python/bfx_qc_reporter", "bfx_qc_reporter.util" : "src/python/bfx_qc_reporter/util"},
 	#package_data = {"bfx_qc_reporter" : "resources/*.csv"},
-	package_data = {"bfx_qc_reporter" : "src/python/bfx_qc_reporter/resources/*.csv"},
+        package_data = {"bfx_qc_reporter" : ["src/python/bfx_qc_reporter/resources/*.csv"]},
     install_requires = [],
     classifiers = [
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
The current setup.py fails to build with the following error in Python 3.7.4

`error in bfx-qc-reporter setup command: "values of 'package_data' dict" must be a list of strings (got 'src/python/bfx_qc_reporter/resources/*.csv')`